### PR TITLE
fix: replace, not add, spec.channel with value of v1.10.

### DIFF
--- a/0-bootstrap/spokeclusters/infra/sec-hub/2-services/kustomization.yaml
+++ b/0-bootstrap/spokeclusters/infra/sec-hub/2-services/kustomization.yaml
@@ -33,7 +33,7 @@ patches:
 - target:
     name: ibm-cp4s-operator
   patch: |-
-    - op: add
+    - op: replace
       path: /spec/source/helm/parameters/-
       value:
         name: spec.channel


### PR DESCRIPTION
Error in previous patch to spec.channel adding rather than replacing the value.