### PR TITLE
fix: remove spec.channel parameter in operator template, then use kustomize to add with value of v1.10.

### DIFF
--- a/0-bootstrap/spokeclusters/infra/sec-hub/2-services/argocd/operators/ibm-cp4s-operator.yaml
+++ b/0-bootstrap/spokeclusters/infra/sec-hub/2-services/argocd/operators/ibm-cp4s-operator.yaml
@@ -27,8 +27,6 @@ spec:
       parameters:
       - name: metadata.name
         value: ibm-cp-security-operator
-      - name: spec.channel
-        value: v1.9
       - name: spec.installPlanApproval
         value: Automatic
       - name: spec.name

--- a/0-bootstrap/spokeclusters/infra/sec-hub/2-services/kustomization.yaml
+++ b/0-bootstrap/spokeclusters/infra/sec-hub/2-services/kustomization.yaml
@@ -33,7 +33,7 @@ patches:
 - target:
     name: ibm-cp4s-operator
   patch: |-
-    - op: replace
+    - op: add
       path: /spec/source/helm/parameters/-
       value:
         name: spec.channel


### PR DESCRIPTION
The CP4S operator template yaml should probably not have a hard-coded spec.channel v1.9 on it that I can't figure out how to replace with kustomize (it's a parameter). Was getting “rpc error: code = Unknown desc = Manifest generation error (cached): `kustomize build .0-bootstrap/spokeclusters/infra/sec-hub/2-services --enable-alpha-plugins` failed exit status 1: Error: replace operation does not apply: doc is missing key: /spec/source/helm/parameters/-: missing value”. This was the patch:

    - target:
        name: ibm-cp4s-operator
      patch: |-
        - op: replace
          path: /spec/source/helm/parameters/-
          value:
            name: spec.channel
            value: v1.10

and the operator template had a hard-coded spec.channel like this:

    spec:
      destination:
        namespace: tools
        server: 'https://kubernetes.default.svc'
      project: services
      syncPolicy:
        automated:
          prune: true
          selfHeal: true
      source:
        chart: ocp-subscription
        repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
        targetRevision: 1.0.0
        helm:
          parameters:
          - name: metadata.name
            value: ibm-cp-security-operator
          - name: spec.channel
            value: v1.9
    ...

So I will follow how the ibm-automation-foundation-operator.yaml does it (found in single-cluster/2-services/argocd/operators/ibm-automation-foundation-operator.yaml), where there is no spec.channel given so kustomize just adds that in.

